### PR TITLE
fix(tiny-async-pool): `doWork` iterator fn must return `Promise<void>`

### DIFF
--- a/.changeset/nasty-dots-look.md
+++ b/.changeset/nasty-dots-look.md
@@ -1,0 +1,12 @@
+---
+"@altano/tiny-async-pool": major
+---
+
+Stricter API: doWork's iteratorFn must return Promise<void>
+
+If you have an iteratorFn that resolves to a non-void value and you still want to use it, you have to be explicit by wrapping it:
+
+```js
+const resolvesToValue = async function () { /* ... */ };
+await doWork(..., async () => { await resolvesToValue(); });
+```

--- a/devbox.lock
+++ b/devbox.lock
@@ -103,6 +103,7 @@
     },
     "nodejs@20.11.1": {
       "last_modified": "2024-02-24T23:06:34Z",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/9a9dae8f6319600fa9aebde37f340975cab4b8c0#nodejs_20",
       "source": "devbox-search",
       "version": "20.11.1",

--- a/packages/tiny-async-pool/README.md
+++ b/packages/tiny-async-pool/README.md
@@ -1,5 +1,7 @@
 # tiny-async-pool
 
+This is an ESM + TypeScript rewrite of [tiny-async-pool](https://www.npmjs.com/package/tiny-async-pool) by Rafael Xavier de Souza.
+
 ## Why?
 
 The goal of this library is to use the native async iterator (ES9), native async functions, and native Promise to implement concurrent/batched work.
@@ -69,17 +71,16 @@ Iterator function that takes two arguments: the value of each iteration and the 
 
 ### `doWork(concurrency, iterable, iteratorFn)`
 
-The same as `doWorkAndYield(...)` but just returns a Promise that resolves when all work resolves/rejects, e.g.:
+Like `doWorkAndYield(...)` but returns a Promise that resolves when all work resolves (or rejects immediately when any Promise rejects). Useful when you don't care about the return of `iteratorFn`, such as a worker pool where you do batch file proccessing and the workers produce a side effect instead of returning a value. For example, a batch file eraser:
 
 ```js
-const timeout = (ms) => new Promise((resolve) => setTimeout(() => resolve(ms), ms));
-
-await doWork(2, [1000, 5000, 3000, 2000], timeout);
+const eraseFile = (path) => fs.unlink(path);
+const eraseFiles = async (files) => doWork(4, files, eraseFile);
 ```
 
-## License
+It will be enforced that `iteratorFn` returns `Promise<void>` when using TypeScript.
 
-This project is a fork of `async-pool` by Rafael Xavier de Souza. It modernizes (as of 2022) the library by being a first-class TypeScript and ESM module.
+## License
 
 MIT © [Rafael Xavier de Souza](http://rafael.xavier.blog.br)
 MIT © [Alan Norbauer](https://alan.norbauer.com)

--- a/packages/tiny-async-pool/src/doWork.ts
+++ b/packages/tiny-async-pool/src/doWork.ts
@@ -1,12 +1,33 @@
-import { doWorkAndYield } from "./doWorkAndYield";
+import { doWorkAndYield, type IterableItem } from "./doWorkAndYield";
 
 /**
  * Process items from `iterable` in batches.
  */
 export async function doWork<TIn, TOut, TIterable extends Iterable<TIn>>(
-  ...args: Parameters<typeof doWorkAndYield<TIn, TOut, TIterable>>
+  /**
+   * The size of the batch of work, or, how many times `iteratorFn` will be
+   * called in parallel.
+   */
+  concurrentCount: number,
+  /**
+   * An iterable that contains the items that should be passed to `iteratorFn`.
+   */
+  iterable: TIterable,
+  /**
+   * The async callback function that does the work. Will be passed items from
+   * `iterable`. Promise returned must not resolve to a value, as it will be
+   * ignored.
+   */
+  iteratorFn: (
+    item: IterableItem<TIterable>,
+    Iterable: TIterable,
+  ) => Promise<void>,
 ): Promise<void> {
-  for await (const _result of doWorkAndYield(...args)) {
+  for await (const _result of doWorkAndYield(
+    concurrentCount,
+    iterable,
+    iteratorFn,
+  )) {
     // no-op
   }
 }

--- a/packages/tiny-async-pool/src/doWorkAndYield.ts
+++ b/packages/tiny-async-pool/src/doWorkAndYield.ts
@@ -1,5 +1,5 @@
 type ExecutingPromise<TOut> = Promise<[ExecutingPromise<TOut>, TOut]>;
-type IterableItem<T> = T extends Iterable<infer R> ? R : never;
+export type IterableItem<T> = T extends Iterable<infer R> ? R : never;
 
 /**
  * Process items from `iterable` in batches and yield the result of each call to

--- a/packages/tiny-async-pool/tests/tsconfig.json
+++ b/packages/tiny-async-pool/tests/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@altano/tsconfig/node.json",
-  "include": [".", "vite.config.ts"],
+  "include": [".", "vite.config.ts", "tests"],
   "compilerOptions": {
     "types": ["vitest/globals"]
   }


### PR DESCRIPTION
Stricter API: doWork's iteratorFn must return Promise<void>

If you have an iteratorFn that resolves to a non-void value and you still want to use it, you have to be explicit by wrapping it:

```js
const resolvesToValue = async function () { /* ... */ };
await doWork(..., async () => { await resolvesToValue(); });
```