### PR TITLE
fix: pnpm publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@2.0.0/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
@@ -13,5 +13,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "privatePackages": false,
   "ignore": []
 }

--- a/examples/satori-fit-text-node-cli/package.json
+++ b/examples/satori-fit-text-node-cli/package.json
@@ -1,5 +1,6 @@
 {
   "name": "satori-fit-text-node-cli",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "description": "Demo of @altano/satori-fit-text",
@@ -17,6 +18,5 @@
   },
   "publishConfig": {
     "access": "restricted"
-  },
-  "version": null
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@altano/npm-packages",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "build": "turbo run build",
@@ -7,7 +8,7 @@
     "clean": "turbo run clean && rm -rf node_modules",
     "dev": "turbo run dev --no-cache --parallel --continue",
     "format": "turbo run format",
-    "lint": "pnpm eslint package.json *.ts && turbo run lint",
+    "lint": "eslint package.json *.ts && turbo run lint",
     "preinstall": "npx only-allow pnpm",
     "prep": "turbo run build test lint format typecheck",
     "release": "turbo run build && changeset publish",
@@ -24,7 +25,7 @@
     "@changesets/cli": "^2.27.1",
     "eslint": "^8.57.0",
     "eslint-config-altano": "workspace:*",
-    "eslint-plugin-package-json": "^0.12.0",
+    "eslint-plugin-package-json": "^0.12.1",
     "jsonc-eslint-parser": "^2.4.0",
     "prettier": "^3.2.5",
     "tsup": "^8.0.2",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@altano/assets",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/build-config/package.json
+++ b/packages/build-config/package.json
@@ -2,6 +2,7 @@
   "name": "@altano/build-config",
   "license": "ISC",
   "type": "module",
+  "version": "0.0.0",
   "private": true,
   "files": [
     "tsup.config.ts",

--- a/packages/eslint-config-altano/index.js
+++ b/packages/eslint-config-altano/index.js
@@ -83,8 +83,8 @@ module.exports = {
       parser: "jsonc-eslint-parser",
       plugins: ["package-json"],
       rules: {
-        "package-json/valid-version": "off",
         "package-json/valid-package-def": "off",
+        "package-json/valid-repository-directory": "off",
       },
     },
   ],

--- a/packages/eslint-config-altano/package.json
+++ b/packages/eslint-config-altano/package.json
@@ -1,5 +1,6 @@
 {
   "name": "eslint-config-altano",
+  "version": "0.0.0",
   "private": true,
   "main": "index.js",
   "license": "ISC",

--- a/packages/remark-plugin-helpers/package.json
+++ b/packages/remark-plugin-helpers/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@altano/remark-plugin-helpers",
+  "version": "0.0.0",
   "private": true,
   "description": "Utilities for remark plugins",
   "type": "module",

--- a/packages/remark-plugin-test-util/package.json
+++ b/packages/remark-plugin-test-util/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@altano/remark-plugin-test-util",
+  "version": "0.0.0",
   "private": true,
   "description": "Testing utilities for remark plugins",
   "type": "module",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -2,6 +2,7 @@
   "name": "@altano/tsconfig",
   "license": "ISC",
   "type": "module",
+  "version": "0.0.0",
   "private": true,
   "files": [
     "base.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         specifier: workspace:*
         version: link:packages/eslint-config-altano
       eslint-plugin-package-json:
-        specifier: ^0.12.0
-        version: 0.12.0(patch_hash=gn5bfpzr3wzegyh5feayqzmjpm)(eslint@8.57.0)(jsonc-eslint-parser@2.4.0)
+        specifier: ^0.12.1
+        version: 0.12.1(eslint@8.57.0)(jsonc-eslint-parser@2.4.0)
       jsonc-eslint-parser:
         specifier: ^2.4.0
         version: 2.4.0
@@ -4317,6 +4317,21 @@ packages:
       validate-npm-package-name: 5.0.0
     dev: true
     patched: true
+
+  /eslint-plugin-package-json@0.12.1(eslint@8.57.0)(jsonc-eslint-parser@2.4.0):
+    resolution: {integrity: sha512-Z70ddt7tvZrdLZv4V1OkoDqGnnFakVRmAAeP+y/18ZvpgoPJXkqa+JRJNh+tWQ2PMZU4CqleZ6tZOEoq47AY2g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: '>=8.0.0'
+      jsonc-eslint-parser: ^2.0.0
+    dependencies:
+      eslint: 8.57.0
+      jsonc-eslint-parser: 2.4.0
+      package-json-validator: 0.6.3
+      semver: 7.6.0
+      sort-package-json: 1.57.0
+      validate-npm-package-name: 5.0.0
+    dev: true
 
   /eslint-plugin-prettier@5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5):
     resolution: {integrity: sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==}


### PR DESCRIPTION
pnpm and changesets are fighting each other. changesets wants unversioned private packages and pnpm wants versioned private packages.

Solution: version private packages (to make `pnpm publish` work) but hide them from changesets with the `privatePackages: false` config option