### PR TITLE
fix: node libraries

### DIFF
--- a/.changeset/grumpy-ghosts-pay.md
+++ b/.changeset/grumpy-ghosts-pay.md
@@ -1,0 +1,10 @@
+---
+"@altano/remark-mdx-toc-with-slugs": patch
+"@altano/repository-tools": patch
+"@altano/satori-fit-text": patch
+"@altano/tiny-async-pool": patch
+"@altano/vitest-plugins": patch
+"@altano/html-cdnify": patch
+---
+
+fix import extensions for node libraries

--- a/packages/html-cdnify/src/CDNTransformer.ts
+++ b/packages/html-cdnify/src/CDNTransformer.ts
@@ -1,7 +1,7 @@
 import { unionBy, merge, mergeWith, type MergeWithCustomizer } from "lodash";
-import urlConverter from "./urlConverter";
+import urlConverter from "./urlConverter.js";
 
-import * as HtmlAttributeStreamTransformer from "./HtmlAttributeStreamTransformer";
+import * as HtmlAttributeStreamTransformer from "./HtmlAttributeStreamTransformer.js";
 
 export type CDNTransformFunction = (
   cdnUrl: string,

--- a/packages/html-cdnify/src/HtmlAttributeStreamTransformer.ts
+++ b/packages/html-cdnify/src/HtmlAttributeStreamTransformer.ts
@@ -1,5 +1,5 @@
 import { groupBy } from "lodash";
-import HtmlTransformer from "./HtmlTransformer";
+import HtmlTransformer from "./HtmlTransformer.js";
 
 export interface HtmlAttributeStreamTransformerOptions {
   transformDefinitions: TransformDefinition[];

--- a/packages/html-cdnify/src/cdnify.ts
+++ b/packages/html-cdnify/src/cdnify.ts
@@ -1,5 +1,5 @@
-import { CDNTransformer, CDNTransformerOptions } from "./CDNTransformer";
-export * from "./CDNTransformer";
+import { CDNTransformer, CDNTransformerOptions } from "./CDNTransformer.js";
+export * from "./CDNTransformer.js";
 
 import streamifier from "streamifier";
 

--- a/packages/html-cdnify/src/index.ts
+++ b/packages/html-cdnify/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./cdnify";
-export * from "./CDNTransformer";
+export * from "./cdnify.js";
+export * from "./CDNTransformer.js";

--- a/packages/html-cdnify/tests/unit/HTMLAttributeStreamTransformer.spec.ts
+++ b/packages/html-cdnify/tests/unit/HTMLAttributeStreamTransformer.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { HtmlAttributeStreamTransformer } from "../../src/HtmlAttributeStreamTransformer";
+import { HtmlAttributeStreamTransformer } from "../../src/HtmlAttributeStreamTransformer.js";
 
 import streamifier from "streamifier";
 

--- a/packages/html-cdnify/tests/unit/urlConverter.spec.ts
+++ b/packages/html-cdnify/tests/unit/urlConverter.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import urlConverter from "../../src/urlConverter";
+import urlConverter from "../../src/urlConverter.js";
 
 describe("urlConverter", function () {
   it("should not convert absolute paths", function () {

--- a/packages/remark-mdx-toc-with-slugs/tests/unit/errors.spec.ts
+++ b/packages/remark-mdx-toc-with-slugs/tests/unit/errors.spec.ts
@@ -22,7 +22,9 @@ describe("remark-mdx-toc-with-slugs", async () => {
         };
       });
 
-      const { default: remarkMdxTocWithSlugs } = await import("../../src");
+      const { default: remarkMdxTocWithSlugs } = await import(
+        "../../src/index.js"
+      );
       expect(() => {
         // @ts-expect-error testing error path
         remarkMdxTocWithSlugs.call(null, {});
@@ -40,7 +42,9 @@ describe("remark-mdx-toc-with-slugs", async () => {
         };
       });
 
-      const { default: remarkMdxTocWithSlugs } = await import("../../src");
+      const { default: remarkMdxTocWithSlugs } = await import(
+        "../../src/index.js"
+      );
       const compileWithPlugin = await getFixtureCompiler(
         remarkMdxTocWithSlugs,
         "basic",
@@ -70,7 +74,9 @@ describe("remark-mdx-toc-with-slugs", async () => {
         };
       });
 
-      const { default: remarkMdxTocWithSlugs } = await import("../../src");
+      const { default: remarkMdxTocWithSlugs } = await import(
+        "../../src/index.js"
+      );
       const compileWithPlugin = await getFixtureCompiler(
         remarkMdxTocWithSlugs,
         "basic",

--- a/packages/remark-mdx-toc-with-slugs/tests/unit/plugin.spec.ts
+++ b/packages/remark-mdx-toc-with-slugs/tests/unit/plugin.spec.ts
@@ -1,4 +1,4 @@
-import plugin from "../../src";
+import plugin from "../../src/index.js";
 import { describe } from "vitest";
 import { testByFixtures } from "@altano/remark-plugin-test-util/testByFixture";
 

--- a/packages/remark-plugin-helpers/src/index.ts
+++ b/packages/remark-plugin-helpers/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./visitAndReplace";
-export * from "./logger";
+export * from "./visitAndReplace.js";
+export * from "./logger.js";

--- a/packages/repository-tools/src/findRoot.ts
+++ b/packages/repository-tools/src/findRoot.ts
@@ -1,4 +1,4 @@
-import { repositoryExec } from "./repositoryCommand";
+import { repositoryExec } from "./repositoryCommand.js";
 
 async function findGitRoot(directory: string): Promise<string> {
   return repositoryExec(directory, "git", [

--- a/packages/repository-tools/src/findRootSync.ts
+++ b/packages/repository-tools/src/findRootSync.ts
@@ -1,4 +1,4 @@
-import { repositoryExecSync } from "./repositoryCommand";
+import { repositoryExecSync } from "./repositoryCommand.js";
 
 function findGitRoot(cwd: string): string {
   return repositoryExecSync(cwd, "git", [

--- a/packages/repository-tools/src/index.ts
+++ b/packages/repository-tools/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./findRoot";
-export * from "./findRootSync";
+export * from "./findRoot.js";
+export * from "./findRootSync.js";

--- a/packages/repository-tools/src/repositoryCommand.ts
+++ b/packages/repository-tools/src/repositoryCommand.ts
@@ -1,4 +1,4 @@
-import { execFileAsync, execFileSync } from "./exec";
+import { execFileAsync, execFileSync } from "./exec.js";
 import {} from "child_process";
 
 type RepositoryCommand = "git" | "hg" | "sl" | "svn" | "svnadmin" | "svnrdump";

--- a/packages/satori-fit-text/src/TextMeasurer/BrowserTextMeasurer.ts
+++ b/packages/satori-fit-text/src/TextMeasurer/BrowserTextMeasurer.ts
@@ -1,7 +1,7 @@
 /* v8 ignore start */
-import log from "../log";
-import { TextMeasurer, type Dimensions } from "./TextMeasurer";
-import getWidthAdjustedForInlineBleed from "./getWidthAdjustedForInlineBleed";
+import log from "../log.js";
+import { TextMeasurer, type Dimensions } from "./TextMeasurer.js";
+import getWidthAdjustedForInlineBleed from "./getWidthAdjustedForInlineBleed.js";
 
 export default class BrowserTextMeasurer extends TextMeasurer {
   #getSvgElement(svgText: string): SVGSVGElement {

--- a/packages/satori-fit-text/src/TextMeasurer/HeadlessTextMeasurer.ts
+++ b/packages/satori-fit-text/src/TextMeasurer/HeadlessTextMeasurer.ts
@@ -1,9 +1,9 @@
 import { SVG, registerWindow, type Svg } from "@svgdotjs/svg.js";
 import { createSVGWindow } from "svgdom";
-import log from "../log";
-import type { Font } from "../types";
-import { TextMeasurer, type Dimensions } from "./TextMeasurer";
-import getWidthAdjustedForInlineBleed from "./getWidthAdjustedForInlineBleed";
+import log from "../log.js";
+import type { Font } from "../types.js";
+import { TextMeasurer, type Dimensions } from "./TextMeasurer.js";
+import getWidthAdjustedForInlineBleed from "./getWidthAdjustedForInlineBleed.js";
 
 export default class HeadlessTextMeasurer extends TextMeasurer {
   #canvas: Svg;

--- a/packages/satori-fit-text/src/TextMeasurer/TextMeasurer.ts
+++ b/packages/satori-fit-text/src/TextMeasurer/TextMeasurer.ts
@@ -1,7 +1,7 @@
 import satori from "satori";
 
 import type React from "react";
-import type { Font } from "../types";
+import type { Font } from "../types.js";
 
 export type Dimensions = Pick<DOMRect, "width" | "height">;
 

--- a/packages/satori-fit-text/src/TextMeasurer/getTextMeasurer.ts
+++ b/packages/satori-fit-text/src/TextMeasurer/getTextMeasurer.ts
@@ -1,4 +1,4 @@
-import type { TextMeasurer } from "./TextMeasurer";
+import type { TextMeasurer } from "./TextMeasurer.js";
 
 export async function getTextMeasurer(
   ...args: ConstructorParameters<typeof TextMeasurer>
@@ -6,10 +6,10 @@ export async function getTextMeasurer(
   // TODO Get browser testing working
   /* v8 ignore next 3 */
   if (typeof window !== "undefined") {
-    const Measurer = await import("./BrowserTextMeasurer");
+    const Measurer = await import("./BrowserTextMeasurer.js");
     return new Measurer.default(...args);
   } else {
-    const Measurer = await import("./HeadlessTextMeasurer");
+    const Measurer = await import("./HeadlessTextMeasurer.js");
     return new Measurer.default(...args);
   }
 }

--- a/packages/satori-fit-text/src/fitText.ts
+++ b/packages/satori-fit-text/src/fitText.ts
@@ -1,6 +1,6 @@
-import { getTextMeasurer } from "./TextMeasurer/getTextMeasurer";
+import { getTextMeasurer } from "./TextMeasurer/getTextMeasurer.js";
 
-import type { Font } from "./types";
+import type { Font } from "./types.js";
 
 export type FindOptions = {
   /**

--- a/packages/satori-fit-text/src/index.ts
+++ b/packages/satori-fit-text/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./fitText";
-export * from "./types";
+export * from "./fitText.js";
+export * from "./types.js";

--- a/packages/satori-fit-text/tests/e2e/app/App.tsx
+++ b/packages/satori-fit-text/tests/e2e/app/App.tsx
@@ -1,5 +1,5 @@
-import FitText from "./FitText";
-import Playground from "./Playground";
+import FitText from "./FitText.js";
+import Playground from "./Playground.js";
 
 export default function App(): React.ReactElement {
   return (

--- a/packages/satori-fit-text/tests/e2e/app/FitText.tsx
+++ b/packages/satori-fit-text/tests/e2e/app/FitText.tsx
@@ -1,6 +1,6 @@
 import { type Font, findLargestUsableFontSize } from "@altano/satori-fit-text";
 import { useState, useLayoutEffect } from "react";
-import { getInter } from "./font";
+import { getInter } from "./font.js";
 
 export type Props = {
   text: string;
@@ -23,7 +23,7 @@ export default function FitText({
   const [timeToComputeMs, setTimeToComputeMs] = useState(0);
 
   useLayoutEffect(() => {
-    async function findFontSize() {
+    async function findFontSize(): Promise<void> {
       performance.mark("findLargestUsableFontSize-start");
       const largestUsableFontSize = await findLargestUsableFontSize({
         lineHeight: lineHeight,
@@ -41,6 +41,7 @@ export default function FitText({
       setTimeToComputeMs(measure.duration);
       setFontSize(largestUsableFontSize);
 
+      // eslint-disable-next-line no-console
       console.log(
         `Largest font-size you can use for the text "${text.substring(
           0,
@@ -51,7 +52,7 @@ export default function FitText({
       );
     }
 
-    findFontSize();
+    void findFontSize();
   }, [height, lineHeight, text, weight, width]);
 
   const style = {

--- a/packages/satori-fit-text/tests/e2e/app/Playground.tsx
+++ b/packages/satori-fit-text/tests/e2e/app/Playground.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import FitText from "./FitText";
+import FitText from "./FitText.js";
 import type { Font } from "satori";
 
 function assertWeightValid(

--- a/packages/satori-fit-text/tests/unit/TextMeasurer.spec.ts
+++ b/packages/satori-fit-text/tests/unit/TextMeasurer.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { getTextMeasurer } from "../../src/TextMeasurer/getTextMeasurer";
-import { getFont } from "./utils/getFont";
+import { getTextMeasurer } from "../../src/TextMeasurer/getTextMeasurer.js";
+import { getFont } from "./utils/getFont.js";
 
 describe("getTextMeasurer", () => {
   describe(".doesSizeFit", () => {

--- a/packages/satori-fit-text/tests/unit/fitText.benchmark.tsx
+++ b/packages/satori-fit-text/tests/unit/fitText.benchmark.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, bench } from "vitest";
-import { getFont } from "./utils/getFont";
+import { getFont } from "./utils/getFont.js";
 import { findLargestUsableFontSize } from "@altano/satori-fit-text";
 
 describe("findLargestUsableFontSize", async () => {

--- a/packages/satori-fit-text/tests/unit/fitText.spec.tsx
+++ b/packages/satori-fit-text/tests/unit/fitText.spec.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable react/prop-types */
 
 import { describe, it, expect } from "vitest";
-import should from "./utils/makeTest";
-import { getFont } from "./utils/getFont";
-import { findLargestUsableFontSize } from "../../src";
+import should from "./utils/makeTest.js";
+import { getFont } from "./utils/getFont.js";
+import { findLargestUsableFontSize } from "../../src/index.js";
 import { doWorkAndYield } from "@altano/tiny-async-pool";
 import os from "node:os";
 

--- a/packages/satori-fit-text/tests/unit/utils/getFont.tsx
+++ b/packages/satori-fit-text/tests/unit/utils/getFont.tsx
@@ -1,5 +1,5 @@
 import { getInterBuffer } from "@altano/assets";
-import type { Font } from "../../../src/types";
+import type { Font } from "../../../src/types.js";
 
 export async function getFont(weight: Font["weight"] = 600): Promise<Font> {
   const interBuffer = await getInterBuffer(weight);

--- a/packages/satori-fit-text/tests/unit/utils/makeTest.tsx
+++ b/packages/satori-fit-text/tests/unit/utils/makeTest.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { type FindOptions, findLargestUsableFontSize } from "../../../src";
+import {
+  type FindOptions,
+  findLargestUsableFontSize,
+} from "../../../src/index.js";
 import { expect, test } from "vitest";
 import { toMatchImageSnapshot } from "jest-image-snapshot";
 import satori from "satori";

--- a/packages/tiny-async-pool/src/doWork.ts
+++ b/packages/tiny-async-pool/src/doWork.ts
@@ -1,4 +1,4 @@
-import { doWorkAndYield, type IterableItem } from "./doWorkAndYield";
+import { doWorkAndYield, type IterableItem } from "./doWorkAndYield.js";
 
 /**
  * Process items from `iterable` in batches.

--- a/packages/tiny-async-pool/src/index.ts
+++ b/packages/tiny-async-pool/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./doWork";
-export * from "./doWorkAndYield";
+export * from "./doWork.js";
+export * from "./doWorkAndYield.js";

--- a/packages/tiny-async-pool/tests/unit/doWork.spec.ts
+++ b/packages/tiny-async-pool/tests/unit/doWork.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { doWork } from "../../src";
+import { doWork } from "../../src/index.js";
 
 const timeout = (i: number): Promise<void> =>
   new Promise<void>((resolve) =>

--- a/packages/tiny-async-pool/tests/unit/doWorkAndYield.spec.ts
+++ b/packages/tiny-async-pool/tests/unit/doWorkAndYield.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { doWorkAndYield } from "../../src";
+import { doWorkAndYield } from "../../src/index.js";
 
 const timeout = (i: number): Promise<number> =>
   new Promise<number>((resolve) =>

--- a/packages/tsconfig/node.json
+++ b/packages/tsconfig/node.json
@@ -4,8 +4,8 @@
   "extends": "./base.json",
   "lib": ["ESNext"],
   "compilerOptions": {
-    "moduleResolution": "bundler",
-    "module": "ES2022",
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
     "target": "ESNext",
     "resolveJsonModule": true
   }

--- a/packages/vitest-plugins/src/matchers/setup.ts
+++ b/packages/vitest-plugins/src/matchers/setup.ts
@@ -1,11 +1,11 @@
 import { expect } from "vitest";
 
-import toBePath from "./toBePath";
-import toBeFile from "./toBeFile";
-import toBeDirectory from "./toBeDirectory";
-import toEqualFile from "./toEqualFile";
-import toMatchError from "./toMatchError";
-import toThrowErrorMatching from "./toThrowErrorMatching";
+import toBePath from "./toBePath.js";
+import toBeFile from "./toBeFile.js";
+import toBeDirectory from "./toBeDirectory.js";
+import toEqualFile from "./toEqualFile.js";
+import toMatchError from "./toMatchError.js";
+import toThrowErrorMatching from "./toThrowErrorMatching.js";
 
 expect.extend({
   toBePath,

--- a/packages/vitest-plugins/src/matchers/toBeDirectory.ts
+++ b/packages/vitest-plugins/src/matchers/toBeDirectory.ts
@@ -1,4 +1,4 @@
-import type { Matcher } from "./matcher";
+import type { Matcher } from "./matcher.js";
 import fs from "node:fs";
 
 function directoryExists(path: string): boolean {

--- a/packages/vitest-plugins/src/matchers/toBeFile.ts
+++ b/packages/vitest-plugins/src/matchers/toBeFile.ts
@@ -1,4 +1,4 @@
-import type { Matcher } from "./matcher";
+import type { Matcher } from "./matcher.js";
 import fs from "node:fs";
 
 function fileExists(path: string): boolean {

--- a/packages/vitest-plugins/src/matchers/toBePath.ts
+++ b/packages/vitest-plugins/src/matchers/toBePath.ts
@@ -1,4 +1,4 @@
-import type { Matcher } from "./matcher";
+import type { Matcher } from "./matcher.js";
 import { realpathSync } from "node:fs";
 
 function getRealpath(path: string): string | null {

--- a/packages/vitest-plugins/src/matchers/toEqualFile.ts
+++ b/packages/vitest-plugins/src/matchers/toEqualFile.ts
@@ -1,4 +1,4 @@
-import type { Matcher } from "./matcher";
+import type { Matcher } from "./matcher.js";
 import fs from "node:fs";
 import crypto from "node:crypto";
 

--- a/packages/vitest-plugins/src/matchers/toMatchError.ts
+++ b/packages/vitest-plugins/src/matchers/toMatchError.ts
@@ -1,5 +1,5 @@
 import { serializeError } from "serialize-error";
-import type { Matcher } from "./matcher";
+import type { Matcher } from "./matcher.js";
 
 const toMatchError: Matcher = function (received: Error, expected: unknown) {
   // If we don't serialize the error before passing it to vitest, vitest will

--- a/packages/vitest-plugins/src/matchers/toThrowErrorMatching.ts
+++ b/packages/vitest-plugins/src/matchers/toThrowErrorMatching.ts
@@ -1,5 +1,5 @@
-import toMatchError from "./toMatchError";
-import type { Matcher } from "./matcher";
+import toMatchError from "./toMatchError.js";
+import type { Matcher } from "./matcher.js";
 
 const toThrowErrorMatching: Matcher = function (
   received: () => never,

--- a/packages/vitest-plugins/src/serializers/setup.ts
+++ b/packages/vitest-plugins/src/serializers/setup.ts
@@ -1,7 +1,7 @@
 import { expect } from "vitest";
 
-import absolutePathSerializer from "./absolutePath";
+import absolutePathSerializer from "./absolutePath.js";
 expect.addSnapshotSerializer(absolutePathSerializer);
 
-import vFileSerializer from "./vFile";
+import vFileSerializer from "./vFile.js";
 expect.addSnapshotSerializer(vFileSerializer);

--- a/packages/vitest-plugins/tests/unit/serializers/absolutePath.spec.ts
+++ b/packages/vitest-plugins/tests/unit/serializers/absolutePath.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import absolutePathSerializer from "../../../src/serializers/absolutePath";
+import absolutePathSerializer from "../../../src/serializers/absolutePath.js";
 expect.addSnapshotSerializer(absolutePathSerializer);
 
 describe("serializers", () => {


### PR DESCRIPTION
(fixes https://github.com/altano/npm-packages/issues/99)

I disabled bundling in tsup (tsup.config.node.ts) for node libraries, but left moduleResolution:bundler in the tsconfig for tsconfig.node.ts. When these are out of sync, TS will not enforce that imports include extensions where necessary for running in Node, and since we're no longer bundling, these import statements break when run in Node.

The fix is to keep these in sync: switch tsconfig/node.json to use moduleResolution:nodenext, and fix all the resulting TS compilation errors by adding .js extensions where appropriate. TS will keep us honest and correct.

tsconfig/browser.json and tsup.config.browser will continue to use moduleResolution:bundler, and will therefore not enforce extensions in imports, but that is good since no bundlers currently require them.