### PR TITLE
chore: Remove sideEffects:true from vitest-plugins

### DIFF
--- a/.changeset/rich-shirts-bow.md
+++ b/.changeset/rich-shirts-bow.md
@@ -1,0 +1,5 @@
+---
+"@altano/vitest-plugins": minor
+---
+
+removed sideEffects:true from package.json

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "turbo run format",
     "lint": "eslint package.json *.ts && turbo run lint",
     "preinstall": "npx only-allow pnpm",
-    "prep": "turbo run build test lint format typecheck",
+    "prep": "turbo run build test lint format typecheck check-exports",
     "release": "turbo run build && changeset publish",
     "test": "turbo run test",
     "update": "pnpm update --latest --interactive",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "tsup --config build-config/tsup.config.node.ts",
     "build:types": "tsc --project tsconfig.declarations.json",
+    "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
     "dev": "pnpm run build --watch",
     "format": "prettier --check src",
     "format:fix": "prettier --write src",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@altano/tsconfig": "workspace:*",
+    "@arethetypeswrong/cli": "^0.15.4",
     "@types/node": "^20.11.25",
     "typescript": "^5.4.2"
   }

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -24,6 +24,7 @@
     "@fontsource/inter": "^5.0.17"
   },
   "devDependencies": {
+    "@altano/build-config": "workspace:*",
     "@altano/tsconfig": "workspace:*",
     "@arethetypeswrong/cli": "^0.15.4",
     "@types/node": "^20.11.25",

--- a/packages/build-config/tsup.config.browser.ts
+++ b/packages/build-config/tsup.config.browser.ts
@@ -4,8 +4,13 @@ export default defineConfig({
   // since we're bundling, index is the only entry
   entry: ["./src/index.ts"],
   format: "esm",
-  onSuccess: "pnpm build:types",
-  dts: false,
+
+  // Because we're bundling, tsc can't generate types for us, so we use tsup's
+  // type gen. The downside is that we don't get declaration maps. Unfortunately
+  // we can't use tsc to ONLY generate declaration maps (and they would be wrong
+  // because it doesn't work on the bundled file anyway).
+  dts: true,
+
   clean: true,
 
   platform: "browser",

--- a/packages/html-cdnify/package.json
+++ b/packages/html-cdnify/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "tsup --config build-config/tsup.config.node.ts",
     "build:types": "tsc --project tsconfig.declarations.json",
+    "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
     "clean": "rm -rf .turbo && rm -rf .tsbuildinfo && rm -rf node_modules && rm -rf dist",
     "dev": "pnpm run build --watch",
     "format": "prettier --check src",
@@ -53,6 +54,7 @@
   },
   "devDependencies": {
     "@altano/tsconfig": "workspace:*",
+    "@arethetypeswrong/cli": "^0.15.4",
     "@types/glob": "^8.1.0",
     "@types/lodash": "^4.14.202",
     "@types/node": "^20.11.25",

--- a/packages/html-cdnify/package.json
+++ b/packages/html-cdnify/package.json
@@ -53,6 +53,7 @@
     "streamifier": "^0.1.1"
   },
   "devDependencies": {
+    "@altano/build-config": "workspace:*",
     "@altano/tsconfig": "workspace:*",
     "@arethetypeswrong/cli": "^0.15.4",
     "@types/glob": "^8.1.0",

--- a/packages/remark-mdx-toc-with-slugs/package.json
+++ b/packages/remark-mdx-toc-with-slugs/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "tsup --config build-config/tsup.config.node.ts",
     "build:types": "tsc --project tsconfig.declarations.json",
+    "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
     "clean": "rm -rf .turbo && rm -rf .tsbuildinfo && rm -rf node_modules && rm -rf dist",
     "dev": "pnpm run build --watch",
     "format": "prettier --check src",
@@ -56,6 +57,7 @@
     "@altano/remark-plugin-test-util": "workspace:*",
     "@altano/tsconfig": "workspace:*",
     "@altano/vitest-plugins": "workspace:*",
+    "@arethetypeswrong/cli": "^0.15.4",
     "@types/node": "^20.11.25",
     "@types/unist": "^3.0.2",
     "@vitest/coverage-v8": "^1.4.0",

--- a/packages/remark-mdx-toc-with-slugs/package.json
+++ b/packages/remark-mdx-toc-with-slugs/package.json
@@ -54,6 +54,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
+    "@altano/build-config": "workspace:*",
     "@altano/remark-plugin-test-util": "workspace:*",
     "@altano/tsconfig": "workspace:*",
     "@altano/vitest-plugins": "workspace:*",

--- a/packages/remark-plugin-helpers/package.json
+++ b/packages/remark-plugin-helpers/package.json
@@ -37,6 +37,7 @@
     "dist/**/*.d.ts"
   ],
   "devDependencies": {
+    "@altano/build-config": "workspace:*",
     "@altano/tsconfig": "workspace:*",
     "@arethetypeswrong/cli": "^0.15.4",
     "@types/debug": "^4.1.12",

--- a/packages/remark-plugin-helpers/package.json
+++ b/packages/remark-plugin-helpers/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "tsup --config build-config/tsup.config.node.ts",
     "build:types": "tsc --project tsconfig.declarations.json",
+    "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
     "clean": "rm -rf .turbo && rm -rf .tsbuildinfo && rm -rf node_modules && rm -rf dist",
     "dev": "pnpm run build --watch",
     "format": "prettier --check src",
@@ -37,6 +38,7 @@
   ],
   "devDependencies": {
     "@altano/tsconfig": "workspace:*",
+    "@arethetypeswrong/cli": "^0.15.4",
     "@types/debug": "^4.1.12",
     "@types/node": "^20.11.25",
     "@types/unist": "^3.0.2",

--- a/packages/repository-tools/README.md
+++ b/packages/repository-tools/README.md
@@ -37,7 +37,3 @@ This is a dual ESM/CJS package, and publishes both a top-level module with all e
 | ESM               | Yes                    | `import { findRoot } from "@altano/repository-tools/findRoot.js";`      |
 | CJS               | No                     | `const { findRoot } = require("@altano/repository-tools")`              |
 | CJS               | Yes                    | `const { findRoot } = require("@altano/repository-tools/findSync.cjs")` |
-
-## Contributing
-
-This is a dual ESM/CJS package which is really hard to get right. Manually run `pnpm build && pnpm dlx @arethetypeswrong/cli --pack` before making any changes that would affect the build, packaging, or publishing.

--- a/packages/repository-tools/package.json
+++ b/packages/repository-tools/package.json
@@ -60,6 +60,7 @@
   },
   "license": "ISC",
   "devDependencies": {
+    "@altano/build-config": "workspace:*",
     "@altano/tsconfig": "workspace:*",
     "@altano/vitest-plugins": "workspace:*",
     "@arethetypeswrong/cli": "^0.15.4",

--- a/packages/repository-tools/package.json
+++ b/packages/repository-tools/package.json
@@ -24,6 +24,7 @@
   ],
   "scripts": {
     "build": "tsup --config build-config/tsup.config.node-hybrid.ts",
+    "check-exports": "attw --pack .",
     "clean": "rm -rf .turbo && rm -rf .tsbuildinfo && rm -rf node_modules && rm -rf dist",
     "dev": "pnpm run build --watch",
     "format": "prettier --check src",
@@ -61,6 +62,7 @@
   "devDependencies": {
     "@altano/tsconfig": "workspace:*",
     "@altano/vitest-plugins": "workspace:*",
+    "@arethetypeswrong/cli": "^0.15.4",
     "@types/node": "^20.11.25",
     "@vitest/coverage-v8": "^1.4.0",
     "@vitest/expect": "^1.4.0",

--- a/packages/satori-fit-text/package.json
+++ b/packages/satori-fit-text/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "tsup --config build-config/tsup.config.node.ts",
     "build:types": "tsc --project tsconfig.declarations.json",
+    "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
     "clean": "rm -rf .turbo && rm -rf .tsbuildinfo && rm -rf node_modules && rm -rf dist",
     "dev": "pnpm run build --watch",
     "format": "prettier --check src",
@@ -63,6 +64,7 @@
     "@altano/assets": "workspace:*",
     "@altano/tiny-async-pool": "workspace:*",
     "@altano/tsconfig": "workspace:*",
+    "@arethetypeswrong/cli": "^0.15.4",
     "@fontsource-variable/inter": "^5.0.17",
     "@fontsource/inter": "^5.0.17",
     "@playwright/test": "1.40.0",

--- a/packages/satori-fit-text/package.json
+++ b/packages/satori-fit-text/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@altano/assets": "workspace:*",
+    "@altano/build-config": "workspace:*",
     "@altano/tiny-async-pool": "workspace:*",
     "@altano/tsconfig": "workspace:*",
     "@arethetypeswrong/cli": "^0.15.4",

--- a/packages/textfit/package.json
+++ b/packages/textfit/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "tsup --config build-config/tsup.config.browser.ts",
     "build:types": "tsc --project tsconfig.declarations.json",
+    "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
     "dev": "pnpm run build --watch",
     "format": "prettier --check src",
     "format:fix": "prettier --write src",
@@ -43,6 +44,7 @@
   "license": "MIT",
   "devDependencies": {
     "@altano/tsconfig": "workspace:*",
+    "@arethetypeswrong/cli": "^0.15.4",
     "@playwright/test": "1.40.0",
     "@types/node": "^20.11.25",
     "typescript": "^5.4.2",

--- a/packages/textfit/package.json
+++ b/packages/textfit/package.json
@@ -43,6 +43,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@altano/build-config": "workspace:*",
     "@altano/tsconfig": "workspace:*",
     "@arethetypeswrong/cli": "^0.15.4",
     "@playwright/test": "1.40.0",

--- a/packages/tiny-async-pool/package.json
+++ b/packages/tiny-async-pool/package.json
@@ -52,6 +52,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@altano/build-config": "workspace:*",
     "@altano/tsconfig": "workspace:*",
     "@arethetypeswrong/cli": "^0.15.4",
     "@types/node": "^20.11.25",

--- a/packages/tiny-async-pool/package.json
+++ b/packages/tiny-async-pool/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "tsup --config build-config/tsup.config.node.ts",
     "build:types": "tsc --project tsconfig.declarations.json",
+    "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
     "clean": "rm -rf .turbo && rm -rf .tsbuildinfo && rm -rf node_modules && rm -rf dist",
     "dev": "pnpm run build --watch",
     "format": "prettier --check src",
@@ -52,6 +53,7 @@
   "license": "MIT",
   "devDependencies": {
     "@altano/tsconfig": "workspace:*",
+    "@arethetypeswrong/cli": "^0.15.4",
     "@types/node": "^20.11.25",
     "@vitest/coverage-v8": "^1.4.0",
     "@vitest/ui": "^1.3.1",

--- a/packages/use-element-observer/package.json
+++ b/packages/use-element-observer/package.json
@@ -44,6 +44,7 @@
     "react": "^18"
   },
   "devDependencies": {
+    "@altano/build-config": "workspace:*",
     "@altano/tsconfig": "workspace:*",
     "@arethetypeswrong/cli": "^0.15.4",
     "@testing-library/jest-dom": "^6.4.2",

--- a/packages/use-element-observer/package.json
+++ b/packages/use-element-observer/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "tsup --config build-config/tsup.config.browser.ts",
-    "build:types": "tsc --project tsconfig.declarations.json",
+    "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
     "clean": "rm -rf .turbo && rm -rf .tsbuildinfo && rm -rf node_modules && rm -rf dist",
     "dev": "pnpm run build --watch",
     "format": "prettier --check src",
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@altano/tsconfig": "workspace:*",
+    "@arethetypeswrong/cli": "^0.15.4",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.2",
     "@types/react": "^18.2.64",

--- a/packages/use-element-observer/tsconfig.declarations.json
+++ b/packages/use-element-observer/tsconfig.declarations.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "emitDeclarationOnly": true,
-    "declaration": true,
-    "declarationMap": true
-  }
-}

--- a/packages/use-toc-visible-sections/package.json
+++ b/packages/use-toc-visible-sections/package.json
@@ -45,6 +45,7 @@
     "react": "^18"
   },
   "devDependencies": {
+    "@altano/build-config": "workspace:*",
     "@altano/tsconfig": "workspace:*",
     "@arethetypeswrong/cli": "^0.15.4",
     "@playwright/test": "1.40.0",

--- a/packages/use-toc-visible-sections/package.json
+++ b/packages/use-toc-visible-sections/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "tsup --config build-config/tsup.config.browser.ts",
-    "build:types": "tsc --project tsconfig.declarations.json",
+    "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
     "clean": "rm -rf .turbo && rm -rf .tsbuildinfo && rm -rf node_modules && rm -rf dist",
     "dev": "pnpm run build --watch",
     "format": "prettier --check src",
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@altano/tsconfig": "workspace:*",
+    "@arethetypeswrong/cli": "^0.15.4",
     "@playwright/test": "1.40.0",
     "@types/node": "^20.11.25",
     "@types/react": "^18.2.64",

--- a/packages/use-toc-visible-sections/tsconfig.declarations.json
+++ b/packages/use-toc-visible-sections/tsconfig.declarations.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "emitDeclarationOnly": true,
-    "declaration": true,
-    "declarationMap": true
-  }
-}

--- a/packages/use-visible-elements/package.json
+++ b/packages/use-visible-elements/package.json
@@ -46,6 +46,7 @@
     "react": "^18"
   },
   "devDependencies": {
+    "@altano/build-config": "workspace:*",
     "@altano/tsconfig": "workspace:*",
     "@arethetypeswrong/cli": "^0.15.4",
     "@playwright/test": "1.40.0",

--- a/packages/use-visible-elements/package.json
+++ b/packages/use-visible-elements/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "tsup --config build-config/tsup.config.browser.ts",
-    "build:types": "tsc --project tsconfig.declarations.json",
+    "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
     "clean": "rm -rf .turbo && rm -rf .tsbuildinfo && rm -rf node_modules && rm -rf dist",
     "dev": "pnpm run build --watch",
     "format": "prettier --check src",
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@altano/tsconfig": "workspace:*",
+    "@arethetypeswrong/cli": "^0.15.4",
     "@playwright/test": "1.40.0",
     "@types/node": "^20.11.25",
     "@types/react": "^18.2.64",

--- a/packages/use-visible-elements/tsconfig.declarations.json
+++ b/packages/use-visible-elements/tsconfig.declarations.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "emitDeclarationOnly": true,
-    "declaration": true,
-    "declarationMap": true
-  }
-}

--- a/packages/vitest-plugins/package.json
+++ b/packages/vitest-plugins/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.1",
   "description": "Custom matchers and snapshot serializers to enhance vitest",
   "type": "module",
-  "sideEffects": false,
   "exports": {
     "./matchers": {
       "default": "./src/matchers/setup.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,6 +332,9 @@ importers:
       '@altano/vitest-plugins':
         specifier: workspace:*
         version: link:../vitest-plugins
+      '@arethetypeswrong/cli':
+        specifier: ^0.15.4
+        version: 0.15.4
       '@types/node':
         specifier: ^20.11.25
         version: 20.11.25
@@ -749,6 +752,18 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@andrewbranch/untar.js@1.0.3':
+    resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
+
+  '@arethetypeswrong/cli@0.15.4':
+    resolution: {integrity: sha512-YDbImAi1MGkouT7f2yAECpUMFhhA1J0EaXzIqoC5GGtK0xDgauLtcsZezm8tNq7d3wOFXH7OnY+IORYcG212rw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@arethetypeswrong/core@0.15.1':
+    resolution: {integrity: sha512-FYp6GBAgsNz81BkfItRz8RLZO03w5+BaeiPma1uCfmxTnxbtuMrI/dbzGiOk8VghO108uFI0oJo0OkewdSHw7g==}
+    engines: {node: '>=18'}
+
   '@babel/code-frame@7.24.2':
     resolution: {integrity: sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==}
     engines: {node: '>=6.9.0'}
@@ -910,6 +925,10 @@ packages:
 
   '@changesets/write@0.3.0':
     resolution: {integrity: sha512-slGLb21fxZVUYbyea+94uFiD6ntQW0M2hIKNznFizDhZPDgn2c/fv1UzzlW43RVzh1BEDuIqW6hzlJ1OflNmcw==}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@esbuild/aix-ppc64@0.20.2':
     resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}
@@ -1604,6 +1623,10 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@svgdotjs/svg.js@3.2.0':
     resolution: {integrity: sha512-Tr8p+QVP7y+QT1GBlq1Tt57IvedVH8zCPoYxdHLX0Oof3a/PqnC/tXAkVufv1JQJfsDHlH/UrjcDfgxSofqSNA==}
 
@@ -1961,6 +1984,10 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-escapes@7.0.0:
+    resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2192,6 +2219,14 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -2230,6 +2265,15 @@ packages:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
 
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -2267,6 +2311,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -2494,6 +2542,9 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
 
@@ -2515,6 +2566,10 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -3062,6 +3117,9 @@ packages:
   hex-rgb@4.3.0:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
     engines: {node: '>=6'}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -3628,6 +3686,17 @@ packages:
     resolution: {integrity: sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==}
     engines: {node: '>=0.10.0'}
 
+  marked-terminal@7.1.0:
+    resolution: {integrity: sha512-+pvwa14KZL74MVXjYdPR3nSInhGhNvPce/3mqLVZT2oUvt654sL1XImFuLZ1pkA866IYZ3ikDTOFUIC7XzpZZg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      marked: '>=1 <14'
+
+  marked@9.1.6:
+    resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
+    engines: {node: '>= 16'}
+    hasBin: true
+
   mdast-util-definitions@5.1.2:
     resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
 
@@ -3980,6 +4049,10 @@ packages:
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
+  node-emoji@2.1.3:
+    resolution: {integrity: sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==}
+    engines: {node: '>=18'}
+
   node-gyp@10.0.1:
     resolution: {integrity: sha512-gg3/bHehQfZivQVfqIyy8wTdSymF9yTyP4CJifK73imyNMU8AIGQE2pUa7dNWfmMeG9cDVF2eehiRMv0LC1iAg==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -4186,6 +4259,15 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   parse5@7.1.2:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
@@ -4705,6 +4787,10 @@ packages:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
 
+  skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -4924,6 +5010,10 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  supports-hyperlinks@3.1.0:
+    resolution: {integrity: sha512-2rn0BZ+/f7puLOHZm1HOJfwBggfaHXUpPUSSG/SWM4TWp5KCfmNYwnC3hruy2rZlMnmWZ+QAGpZfchu3f3695A==}
+    engines: {node: '>=14.18'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -5050,6 +5140,9 @@ packages:
   ts-easing@0.2.0:
     resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}
 
+  ts-expose-internals-conditionally@1.0.0-empty.0:
+    resolution: {integrity: sha512-F8m9NOF6ZhdOClDVdlM8gj3fDCav4ZIFSs/EI3ksQbAAXVSCN/Jh5OCJDDZWBuBy9psFc6jULGDlPwjMYMhJDw==}
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -5168,6 +5261,11 @@ packages:
     resolution: {integrity: sha512-yMi0PlwuznKHxKmcpoOdeLwxBoVPkqZxd7q2FgMkmD3bNwvF5VW0+UlUQ1k1vmktTu4Yu13Q0RIxEP8+B+wloA==}
     engines: {node: '>= 0.4'}
 
+  typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
     engines: {node: '>=14.17'}
@@ -5184,6 +5282,10 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
+    engines: {node: '>=4'}
 
   unicode-properties@1.4.1:
     resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
@@ -5565,6 +5667,27 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@andrewbranch/untar.js@1.0.3': {}
+
+  '@arethetypeswrong/cli@0.15.4':
+    dependencies:
+      '@arethetypeswrong/core': 0.15.1
+      chalk: 4.1.2
+      cli-table3: 0.6.5
+      commander: 10.0.1
+      marked: 9.1.6
+      marked-terminal: 7.1.0(marked@9.1.6)
+      semver: 7.6.0
+
+  '@arethetypeswrong/core@0.15.1':
+    dependencies:
+      '@andrewbranch/untar.js': 1.0.3
+      fflate: 0.8.2
+      semver: 7.6.0
+      ts-expose-internals-conditionally: 1.0.0-empty.0
+      typescript: 5.3.3
+      validate-npm-package-name: 5.0.0
+
   '@babel/code-frame@7.24.2':
     dependencies:
       '@babel/highlight': 7.24.2
@@ -5856,6 +5979,9 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 1.0.2
       prettier: 2.8.8
+
+  '@colors/colors@1.5.0':
+    optional: true
 
   '@esbuild/aix-ppc64@0.20.2':
     optional: true
@@ -6398,6 +6524,8 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@sindresorhus/is@4.6.0': {}
+
   '@svgdotjs/svg.js@3.2.0': {}
 
   '@swc/helpers@0.4.14':
@@ -6839,6 +6967,10 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
+  ansi-escapes@7.0.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.0.1: {}
@@ -7108,6 +7240,10 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.3.0: {}
+
+  char-regex@1.0.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -7152,6 +7288,21 @@ snapshots:
 
   clean-stack@2.2.0: {}
 
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.0
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
@@ -7191,6 +7342,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@10.0.1: {}
 
   commander@4.1.1: {}
 
@@ -7407,6 +7560,8 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  emojilib@2.4.0: {}
+
   encoding@0.1.13:
     dependencies:
       iconv-lite: 0.6.3
@@ -7429,6 +7584,8 @@ snapshots:
   entities@4.5.0: {}
 
   env-paths@2.2.1: {}
+
+  environment@1.1.0: {}
 
   err-code@2.0.3: {}
 
@@ -8283,6 +8440,8 @@ snapshots:
 
   hex-rgb@4.3.0: {}
 
+  highlight.js@10.7.3: {}
+
   hosted-git-info@2.8.9: {}
 
   hosted-git-info@7.0.1:
@@ -8856,6 +9015,18 @@ snapshots:
   map-obj@4.3.0: {}
 
   markdown-extensions@1.1.1: {}
+
+  marked-terminal@7.1.0(marked@9.1.6):
+    dependencies:
+      ansi-escapes: 7.0.0
+      chalk: 5.3.0
+      cli-highlight: 2.1.11
+      cli-table3: 0.6.5
+      marked: 9.1.6
+      node-emoji: 2.1.3
+      supports-hyperlinks: 3.1.0
+
+  marked@9.1.6: {}
 
   mdast-util-definitions@5.1.2:
     dependencies:
@@ -9519,6 +9690,13 @@ snapshots:
 
   nice-try@1.0.5: {}
 
+  node-emoji@2.1.3:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
+
   node-gyp@10.0.1:
     dependencies:
       env-paths: 2.2.1
@@ -9800,6 +9978,14 @@ snapshots:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
 
   parse5@7.1.2:
     dependencies:
@@ -10378,6 +10564,10 @@ snapshots:
       mrmime: 2.0.0
       totalist: 3.0.1
 
+  skin-tone@2.0.0:
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
+
   slash@3.0.0: {}
 
   smart-buffer@4.2.0: {}
@@ -10629,6 +10819,11 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-hyperlinks@3.1.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svgdom@0.1.19:
@@ -10745,6 +10940,8 @@ snapshots:
       ts-tiny-invariant: 0.0.3
 
   ts-easing@0.2.0: {}
+
+  ts-expose-internals-conditionally@1.0.0-empty.0: {}
 
   ts-interface-checker@0.1.13: {}
 
@@ -10879,6 +11076,8 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
 
+  typescript@5.3.3: {}
+
   typescript@5.4.2: {}
 
   ufo@1.4.0: {}
@@ -10893,6 +11092,8 @@ snapshots:
       which-boxed-primitive: 1.0.2
 
   undici-types@5.26.5: {}
+
+  unicode-emoji-modifier-base@1.0.0: {}
 
   unicode-properties@1.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
         specifier: ^5.0.17
         version: 5.0.17
     devDependencies:
+      '@altano/build-config':
+        specifier: workspace:*
+        version: link:../build-config
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -138,6 +141,9 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1
     devDependencies:
+      '@altano/build-config':
+        specifier: workspace:*
+        version: link:../build-config
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -214,6 +220,9 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
     devDependencies:
+      '@altano/build-config':
+        specifier: workspace:*
+        version: link:../build-config
       '@altano/remark-plugin-test-util':
         specifier: workspace:*
         version: link:../remark-plugin-test-util
@@ -260,6 +269,9 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
     devDependencies:
+      '@altano/build-config':
+        specifier: workspace:*
+        version: link:../build-config
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -338,6 +350,9 @@ importers:
 
   packages/repository-tools:
     devDependencies:
+      '@altano/build-config':
+        specifier: workspace:*
+        version: link:../build-config
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -411,6 +426,9 @@ importers:
       '@altano/assets':
         specifier: workspace:*
         version: link:../assets
+      '@altano/build-config':
+        specifier: workspace:*
+        version: link:../build-config
       '@altano/tiny-async-pool':
         specifier: workspace:*
         version: link:../tiny-async-pool
@@ -486,6 +504,9 @@ importers:
 
   packages/textfit:
     devDependencies:
+      '@altano/build-config':
+        specifier: workspace:*
+        version: link:../build-config
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -510,6 +531,9 @@ importers:
 
   packages/tiny-async-pool:
     devDependencies:
+      '@altano/build-config':
+        specifier: workspace:*
+        version: link:../build-config
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -561,6 +585,9 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
+      '@altano/build-config':
+        specifier: workspace:*
+        version: link:../build-config
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -616,6 +643,9 @@ importers:
         specifier: workspace:*
         version: link:../use-visible-elements
     devDependencies:
+      '@altano/build-config':
+        specifier: workspace:*
+        version: link:../build-config
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -668,6 +698,9 @@ importers:
         specifier: ^17.5.0
         version: 17.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
+      '@altano/build-config':
+        specifier: workspace:*
+        version: link:../build-config
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,6 +543,9 @@ importers:
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@arethetypeswrong/cli':
+        specifier: ^0.15.4
+        version: 0.15.4
       '@testing-library/jest-dom':
         specifier: ^6.4.2
         version: 6.4.2(@types/jest@29.5.12)(vitest@1.4.0(@types/node@20.11.25)(@vitest/ui@1.4.0)(jsdom@24.0.0))
@@ -595,6 +598,9 @@ importers:
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@arethetypeswrong/cli':
+        specifier: ^0.15.4
+        version: 0.15.4
       '@playwright/test':
         specifier: 1.40.0
         version: 1.40.0
@@ -644,6 +650,9 @@ importers:
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@arethetypeswrong/cli':
+        specifier: ^0.15.4
+        version: 0.15.4
       '@playwright/test':
         specifier: 1.40.0
         version: 1.40.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@arethetypeswrong/cli':
+        specifier: ^0.15.4
+        version: 0.15.4
       '@types/node':
         specifier: ^20.11.25
         version: 20.11.25
@@ -138,6 +141,9 @@ importers:
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@arethetypeswrong/cli':
+        specifier: ^0.15.4
+        version: 0.15.4
       '@types/glob':
         specifier: ^8.1.0
         version: 8.1.0
@@ -217,6 +223,9 @@ importers:
       '@altano/vitest-plugins':
         specifier: workspace:*
         version: link:../vitest-plugins
+      '@arethetypeswrong/cli':
+        specifier: ^0.15.4
+        version: 0.15.4
       '@types/node':
         specifier: ^20.11.25
         version: 20.11.25
@@ -254,6 +263,9 @@ importers:
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@arethetypeswrong/cli':
+        specifier: ^0.15.4
+        version: 0.15.4
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -405,6 +417,9 @@ importers:
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@arethetypeswrong/cli':
+        specifier: ^0.15.4
+        version: 0.15.4
       '@fontsource-variable/inter':
         specifier: ^5.0.17
         version: 5.0.17
@@ -474,6 +489,9 @@ importers:
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@arethetypeswrong/cli':
+        specifier: ^0.15.4
+        version: 0.15.4
       '@playwright/test':
         specifier: 1.40.0
         version: 1.40.0
@@ -495,6 +513,9 @@ importers:
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@arethetypeswrong/cli':
+        specifier: ^0.15.4
+        version: 0.15.4
       '@types/node':
         specifier: ^20.11.25
         version: 20.11.25

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,9 @@
       "outputs": ["dist/**", ".next/**"],
       "dependsOn": ["lint", "^build"]
     },
+    "check-exports": {
+      "dependsOn": ["build"]
+    },
     "format": {
       "cache": false
     },


### PR DESCRIPTION

Since the setup code has side effects, let's not lie about this in package.json.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/altano/npm-packages/pull/110).
* __->__ #110
* #109
* #108
* #107
* #106