### PR TITLE
chore: vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "eslint.enable": true,
-  "vitest.enable": true,
+  "vitest.enable": false,
   "prettier.enable": true,
   "biome.enabled": false,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
@@ -26,5 +26,6 @@
   "turbo.path": "./node_modules/.bin/turbo",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.tsdk": "node_modules/typescript/lib",
-  "vitest.disableWorkspaceWarning": true
+  "vitest.disableWorkspaceWarning": true,
+  "search.followSymlinks": false
 }


### PR DESCRIPTION
- disable vitest at workspace level (does not yet work with turbo)
- `"search.followSymlinks": false` to workaround vscode spawning lots of `rg` (ripgrep) processes for some unknown reason