### PR TITLE
turbo: enable custom remote cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,9 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-# To use Turborepo Remote Caching, set the following environment variables for the job.
+# Use Turborepo remote caching w/ custom cache server
 env:
+  TURBO_API: ${{ vars.TURBO_API }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,9 @@ concurrency:
   group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || ''}}
   cancel-in-progress: true
 
-# To use Turborepo Remote Caching, set the following environment variables for the job.
+# Use Turborepo remote caching w/ custom cache server
 env:
+  TURBO_API: ${{ vars.TURBO_API }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ dist-ssr
 .cache
 server/dist
 public/dist
-.turbo
 .coverage
 tsconfig.tsbuildinfo
 .devbox

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,10 @@
 {
   "$schema": "./node_modules/turbo/schema.json",
   "globalEnv": ["CI", "NODE_ENV"],
+  "remoteCache": {
+    // Not yet supported by ducktors/turborepo-remote-cache (https://github.com/ducktors/turborepo-remote-cache/issues/394)
+    "signature": false
+  },
   "tasks": {
     "build": {
       "outputs": ["dist/**", ".next/**"],


### PR DESCRIPTION
Switch from vercel's free remote caching provider (which constantly throttles with this monorepo's builds) to a custom, self-hosted one using https://github.com/ducktors/turborepo-remote-cache with no limits.

Seems to work great. Missing support for `"signature": true` in turbo.json, though.