### PR TITLE
astro-opengraph: component additions + export tests (alpha.3 release)

### DIFF
--- a/.changeset/cruel-frogs-brake.md
+++ b/.changeset/cruel-frogs-brake.md
@@ -1,0 +1,5 @@
+---
+"@altano/astro-opengraph": minor
+---
+
+add `alt` prop to component, test exports, etc

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -26,6 +26,7 @@
     "@altano/astro-opengraph": "0.0.1-alpha.0"
   },
   "changesets": [
+    "cruel-frogs-brake",
     "grumpy-boxes-send",
     "slick-wombats-cut"
   ]

--- a/packages/astro-opengraph/CHANGELOG.md
+++ b/packages/astro-opengraph/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @altano/astro-opengraph
 
+## 0.1.0-alpha.3
+
+### Minor Changes
+
+- e459146: add `alt` prop to component, test exports, etc
+
 ## 0.0.1-alpha.2
 
 ### Patch Changes

--- a/packages/astro-opengraph/README.md
+++ b/packages/astro-opengraph/README.md
@@ -86,7 +86,7 @@ In order serve the component from the prior step as an image, you need a js/ts [
 
 ```ts
 import opengraphTemplate from "../components/opengraph.astro";
-import { makeOpengraphEndpoint } from "@altano/astro-opengraph";
+import { makeOpengraphEndpoint } from "@altano/astro-opengraph/endpoint";
 
 export const GET = makeOpengraphEndpoint({
   template: opengraphTemplate,
@@ -141,6 +141,8 @@ import OpenGraphMeta from "@altano/astro-opengraph/components/meta.astro";
   </body>
 </html>
 ```
+
+You can also provide an `alt` prop which would set the `og:image:alt` meta tag, but my understanding is that it isn't well supported, so feel free to omit this.
 
 If you want the `OpenGraphMeta` component to use a different set of defaults for your whole site, you can provide the `componentMetaTagFallbacks` integration config, e.g. to provide a default title:
 
@@ -274,7 +276,7 @@ It doesn't matter where you put your Open Graph component or endpoints, as long 
 ```ts
 // import your component, wherever it is
 import opengraphTemplate from "../components/my-custom-component.astro";
-import { makeOpengraphEndpoint } from "@altano/astro-opengraph";
+import { makeOpengraphEndpoint } from "@altano/astro-opengraph/endpoint";
 
 export const GET = makeOpengraphEndpoint({
   template: opengraphTemplate,

--- a/packages/astro-opengraph/components/meta.astro
+++ b/packages/astro-opengraph/components/meta.astro
@@ -22,6 +22,10 @@ export type Props = {
    */
   image?: string;
   /**
+   * The specification says "A description of what is in the image (not a caption). If the page specifies an og:image it should specify og:image:alt." but people have found this to be poorly supported. Use if you want.
+   */
+  alt?: string;
+  /**
    * Override the width, which otherwise defaults to:
    *
    * - The width passed into the integration config in astro.config.ts, if set
@@ -42,9 +46,9 @@ export type Props = {
    */
   height?: number;
   /**
-   * Override the mimetype, which defaults to "image/png"
+   * Override `og:image:type` MIME type, which defaults to "image/png"
    */
-  mimeType?: string;
+  type?: string;
 };
 
 const { imageOptions, componentMetaTagFallbacks } = await getResolvedConfig();
@@ -56,12 +60,13 @@ const {
 } = componentMetaTagFallbacks;
 
 const {
+  alt,
   title = titleFallback,
   description = descriptionFallback,
   image = imageUrlFallback,
   width = imageOptions.width,
   height = imageOptions.height,
-  mimeType = "image/png",
+  type = "image/png",
 } = Astro.props;
 
 const urlStr = Astro.url.toString();
@@ -72,6 +77,7 @@ const opengraphImageUrl = new URL(image, urlWithTrailingSlash);
 {title && <meta property="og:title" content={title} />}
 {description && <meta property="og:description" content={description} />}
 <meta property="og:image" content={opengraphImageUrl.toString()} />
-<meta property="og:image:type" content={mimeType} />
+{alt && <meta property="og:image:alt" content={alt} />}
+<meta property="og:image:type" content={type} />
 <meta property="og:image:width" content={width.toString()} />
 <meta property="og:image:height" content={height.toString()} />

--- a/packages/astro-opengraph/package.json
+++ b/packages/astro-opengraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@altano/astro-opengraph",
-  "version": "0.0.1-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Open Graph Tools for Astro",
   "keywords": [
     "astro",
@@ -36,6 +36,7 @@
   ],
   "scripts": {
     "build": "tsdown",
+    "check:types:astro": "node --experimental-strip-types ./scripts/check-fixtures.ts",
     "check:types:src": "tsc --noEmit",
     "check:types:test": "tsc --noEmit --project ./tests/tsconfig.json",
     "check:unused-dependencies": "depcheck",
@@ -60,8 +61,10 @@
     "@altano/assets": "workspace:*",
     "@altano/build-config": "workspace:*",
     "@altano/testing": "workspace:*",
+    "@altano/tiny-async-pool": "workspace:*",
     "@altano/tsconfig": "workspace:*",
     "@altano/vitest-plugins": "workspace:*",
+    "@astrojs/check": "^0.9.4",
     "@inox-tools/astro-tests": "0.5.1",
     "@playwright/test": "catalog:",
     "@types/he": "^1.2.3",
@@ -79,7 +82,8 @@
     "tsdown": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "zx": "^8.5.2"
   },
   "peerDependencies": {
     "@types/react": ">=18",

--- a/packages/astro-opengraph/scripts/check-fixtures.ts
+++ b/packages/astro-opengraph/scripts/check-fixtures.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env zx
+
+import { $, echo, glob, os, path } from "zx";
+import { doWork } from "@altano/tiny-async-pool";
+
+const matches = await glob("./tests/fixtures/**/package.json");
+const fixtures = matches.map((m) => path.dirname(m));
+echo(`Found ${fixtures.length} fixtures`);
+// `astro check` fixtures in parallel
+await doWork(
+  os.cpus().length, // use all CPUs
+  fixtures,
+  async (fixture) => {
+    echo(`Checking "${fixture}"`);
+    await $`pnpm astro check --root "${fixture}"`;
+  },
+);
+echo("done, all fixtures passed");

--- a/packages/astro-opengraph/src/index.ts
+++ b/packages/astro-opengraph/src/index.ts
@@ -1,1 +1,6 @@
 export { default } from "./integration.js";
+export type {
+  OpengraphImageConfig,
+  ImageOptionsWithFontPaths,
+  ComponentMetaTagFallbacks,
+} from "./types.js";

--- a/packages/astro-opengraph/tests/fixtures/custom-dimensions/src/pages/component-uses/prop-overrides.astro
+++ b/packages/astro-opengraph/tests/fixtures/custom-dimensions/src/pages/component-uses/prop-overrides.astro
@@ -4,6 +4,6 @@ import OpenGraphMeta from "../../../../../../components/meta.astro";
 
 <html>
   <head>
-    <OpenGraphMeta width={78} height={911} />
+    <OpenGraphMeta width={78} height={911} alt="alternative alt text" />
   </head>
 </html>

--- a/packages/astro-opengraph/tests/fixtures/ssg/src/pages/component-uses/custom-props.astro
+++ b/packages/astro-opengraph/tests/fixtures/ssg/src/pages/component-uses/custom-props.astro
@@ -10,7 +10,7 @@ import OpenGraphMeta from "../../../../../../components/meta.astro";
       title="I'm a computer"
       description="stop all the downloadin"
       image="./face.png"
-      mimeType="image/facemime"
+      type="image/facemime"
     />
   </head>
 </html>

--- a/packages/astro-opengraph/tests/fixtures/ssr/src/pages/component-uses/custom-props.astro
+++ b/packages/astro-opengraph/tests/fixtures/ssr/src/pages/component-uses/custom-props.astro
@@ -10,7 +10,7 @@ import OpenGraphMeta from "../../../../../../components/meta.astro";
       title="I'm a computer"
       description="stop all the downloadin"
       image="./face.png"
-      mimeType="image/facemime"
+      type="image/facemime"
     />
   </head>
 </html>

--- a/packages/astro-opengraph/tests/unit/custom-dimensions.spec.ts
+++ b/packages/astro-opengraph/tests/unit/custom-dimensions.spec.ts
@@ -49,6 +49,11 @@ describe("Custom Dimensions", () => {
 
       expect(html).toContain(`<meta property="og:image:width" content="78">`);
       expect(html).toContain(`<meta property="og:image:height" content="911">`);
+
+      // doesn't belong here but check we can set the alt tag while we're here...
+      expect(html).toContain(
+        `<meta property="og:image:alt" content="alternative alt text">`,
+      );
     });
   });
 });

--- a/packages/astro-opengraph/tests/unit/exports.spec.ts
+++ b/packages/astro-opengraph/tests/unit/exports.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import integration from "@altano/astro-opengraph";
+import { makeOpengraphEndpoint } from "@altano/astro-opengraph/endpoint";
+import toolbar from "@altano/astro-opengraph/toolbar";
+import OpenGraphMeta from "@altano/astro-opengraph/components/meta.astro?raw";
+
+describe("package exports", () => {
+  it("should have defined exports", () => {
+    expect(integration).toBeDefined();
+    expect(makeOpengraphEndpoint).toBeDefined();
+    expect(toolbar).toBeDefined();
+
+    // have to import .astro component w/ ?raw because our unit tests can't
+    // import .astro files as-is
+    expect(OpenGraphMeta).toBeDefined();
+    expect(OpenGraphMeta.split("\n").slice(0, 2)).toMatchInlineSnapshot(`
+      [
+        "---",
+        "import { getResolvedConfig } from "../src/config";",
+      ]
+    `);
+  });
+});

--- a/packages/astro-opengraph/tsconfig.json
+++ b/packages/astro-opengraph/tsconfig.json
@@ -1,6 +1,12 @@
 {
   "extends": "@altano/tsconfig/node.json",
-  "include": ["src", "components", "src/virtual.d.ts", "*.config.ts"],
+  "include": [
+    "src",
+    "components",
+    "src/virtual.d.ts",
+    "*.config.ts",
+    "scripts"
+  ],
   "compilerOptions": {
     "lib": ["dom"],
     "jsx": "react-jsx",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -106,9 +106,13 @@ export default {
         },
       },
 
-      // disabled rules for dev-only packages
+      // disabled rules for dev-only packages/modules
       {
-        files: ["packages/build-config/**/*", ".syncpackrc.js"],
+        files: [
+          "packages/build-config/**/*",
+          ".syncpackrc.js",
+          "packages/**/scripts/**/*",
+        ],
         rules: {
           "import-x/no-extraneous-dependencies": "off",
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,12 +215,18 @@ importers:
       '@altano/testing':
         specifier: workspace:*
         version: link:../testing
+      '@altano/tiny-async-pool':
+        specifier: workspace:*
+        version: link:../tiny-async-pool
       '@altano/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       '@altano/vitest-plugins':
         specifier: workspace:*
         version: link:../vitest-plugins
+      '@astrojs/check':
+        specifier: ^0.9.4
+        version: 0.9.4(prettier@3.5.3)(typescript@5.8.2)
       '@inox-tools/astro-tests':
         specifier: 0.5.1
         version: 0.5.1(astro@5.8.1(@types/node@22.13.10)(encoding@0.1.13)(jiti@2.4.2)(rollup@4.38.0)(typescript@5.8.2)(yaml@2.8.0))
@@ -275,6 +281,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 3.1.4(@types/debug@4.1.12)(@types/node@22.13.10)(happy-dom@17.4.4)(jiti@2.4.2)(jsdom@26.0.0)(yaml@2.8.0)
+      zx:
+        specifier: ^8.5.2
+        version: 8.5.3
 
   packages/astro-prettier-response:
     dependencies:

--- a/todo.txt
+++ b/todo.txt
@@ -59,7 +59,7 @@ TODO: investigate going esm-only with require(esm) now landed
 astro-opengraph todo:
 TODO: Add tests for `componentMetaTagFallbacks` config
 TODO: look into injecting types automatically (either https://docs.astro.build/en/reference/integrations-reference/#injecttypes-options or https://astro-integration-kit.netlify.app)
-TODO: Run `astro check` on fixture directories (for typechecking etc)
+x 2025-04-09 TODO: Run `astro check` on fixture directories (for typechecking etc)
 x 2025-04-06 TODO: add a toolbar like the one in https://github.com/tombl/astro-opengraph-image (separate package?). document in readme.
 TODO: experiment with `<style is:inline />` (https://docs.astro.build/en/guides/styling/#raw-css-imports)
 x 2025-03-29 TODO: add tests (and documentation) for alternate image formats back in OR


### PR DESCRIPTION
- type check (using `astro check`) all the fixture directories
- add `alt` prop to opengraph component (and test and document)
- fix readme examples for importing endpoint helper
- export useful TS types from integration
- add unit test to make sure exports are correct