### PR TITLE
fix source map situation with tsdown

### DIFF
--- a/.changeset/wicked-parents-camp.md
+++ b/.changeset/wicked-parents-camp.md
@@ -1,0 +1,12 @@
+---
+"@altano/remark-mdx-toc-with-slugs": patch
+"@altano/astro-prettier-response": patch
+"@altano/repository-tools": patch
+"@altano/astro-opengraph": patch
+"@altano/satori-fit-text": patch
+"@altano/tiny-async-pool": patch
+"@altano/remark-mdx-toc": patch
+"@altano/html-cdnify": patch
+---
+
+export source maps

--- a/packages/astro-opengraph/package.json
+++ b/packages/astro-opengraph/package.json
@@ -36,6 +36,7 @@
     "assets",
     "components",
     "dist/**/*.js",
+    "dist/**/*.js.map",
     "dist/**/*.d.ts"
   ],
   "scripts": {

--- a/packages/astro-prettier-response/package.json
+++ b/packages/astro-prettier-response/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist/**/*.js",
+    "dist/**/*.js.map",
     "dist/**/*.d.ts"
   ],
   "scripts": {

--- a/packages/html-cdnify/package.json
+++ b/packages/html-cdnify/package.json
@@ -27,6 +27,7 @@
   "files": [
     "assets/logo.png",
     "dist/**/*.js",
+    "dist/**/*.js.map",
     "dist/**/*.d.ts"
   ],
   "scripts": {

--- a/packages/remark-mdx-toc-with-slugs/package.json
+++ b/packages/remark-mdx-toc-with-slugs/package.json
@@ -27,6 +27,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*.js",
+    "dist/**/*.js.map",
     "dist/**/*.d.ts"
   ],
   "scripts": {

--- a/packages/remark-mdx-toc/package.json
+++ b/packages/remark-mdx-toc/package.json
@@ -25,6 +25,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*.js",
+    "dist/**/*.js.map",
     "dist/**/*.d.ts"
   ],
   "scripts": {

--- a/packages/remark-plugin-helpers/package.json
+++ b/packages/remark-plugin-helpers/package.json
@@ -21,6 +21,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*.js",
+    "dist/**/*.js.map",
     "dist/**/*.d.ts"
   ],
   "scripts": {

--- a/packages/repository-tools/package.json
+++ b/packages/repository-tools/package.json
@@ -32,6 +32,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*.js",
+    "dist/**/*.js.map",
     "dist/**/*.d.ts"
   ],
   "scripts": {

--- a/packages/satori-fit-text/package.json
+++ b/packages/satori-fit-text/package.json
@@ -27,6 +27,7 @@
   "files": [
     "assets/",
     "dist/**/*.js",
+    "dist/**/*.js.map",
     "dist/**/*.d.ts"
   ],
   "scripts": {

--- a/packages/tiny-async-pool/package.json
+++ b/packages/tiny-async-pool/package.json
@@ -33,6 +33,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**/*.js",
+    "dist/**/*.js.map",
     "dist/**/*.d.ts"
   ],
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ catalogs:
       specifier: ^5.25.12
       version: 5.34.9
     tsdown:
-      specifier: ^0.12.3
-      version: 0.12.3
+      specifier: ^0.12.9
+      version: 0.12.9
     typescript:
       specifier: ^5.8.2
       version: 5.8.2
@@ -207,7 +207,7 @@ importers:
         version: 1.4.7
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -292,7 +292,7 @@ importers:
         version: 5.34.9
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -359,7 +359,7 @@ importers:
         version: 3.5.3
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -427,7 +427,7 @@ importers:
         version: 9.23.0(jiti@2.4.2)
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -533,7 +533,7 @@ importers:
         version: 3.5.3
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -622,7 +622,7 @@ importers:
         version: 3.5.3
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -692,7 +692,7 @@ importers:
         version: 3.5.3
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -741,7 +741,7 @@ importers:
         version: 3.5.3
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -784,7 +784,7 @@ importers:
         version: 3.5.3
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -838,7 +838,7 @@ importers:
         version: 0.0.9
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -929,7 +929,7 @@ importers:
         version: 19.1.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -981,7 +981,7 @@ importers:
         version: 3.5.3
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -1011,7 +1011,7 @@ importers:
         version: 1.4.7
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -1053,7 +1053,7 @@ importers:
         version: 3.5.3
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -1120,7 +1120,7 @@ importers:
         version: 19.1.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -1175,7 +1175,7 @@ importers:
         version: 19.1.0(react@19.1.0)
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -1233,7 +1233,7 @@ importers:
         version: 19.1.0(react@19.1.0)
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -1306,7 +1306,7 @@ importers:
         version: 3.5.3
       tsdown:
         specifier: 'catalog:'
-        version: 0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0)
+        version: 0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -3300,8 +3300,8 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
-  ansis@4.0.0:
-    resolution: {integrity: sha512-P8nrHI1EyW9OfBt1X7hMSwGN2vwRuqHSKJAT1gbLWZRzDa24oHjYwGHvEgHeBepupzk878yS/HBZ0NMPYtbolw==}
+  ansis@4.1.0:
+    resolution: {integrity: sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==}
     engines: {node: '>=14'}
 
   any-promise@1.3.0:
@@ -3391,8 +3391,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-kit@2.0.0:
-    resolution: {integrity: sha512-P63jzlYNz96MF9mCcprU+a7I5/ZQ5QAn3y+mZcPWEcGV3CHF/GWnkFPj3oCrWLUjL47+PD9PNiCUdXxw0cWdsg==}
+  ast-kit@2.1.0:
+    resolution: {integrity: sha512-ROM2LlXbZBZVk97crfw8PGDOBzzsJvN2uJCmwswvPUNyfH14eg90mSN3xNqsri1JS1G9cz0VzeDUhxJkTrr4Ew==}
     engines: {node: '>=20.18.0'}
 
   ast-types-flow@0.0.8:
@@ -3469,6 +3469,9 @@ packages:
 
   birpc@2.3.0:
     resolution: {integrity: sha512-ijbtkn/F3Pvzb6jHypHRyve2QApOCZDR25D/VnkY2G/lBNcXCTsnsCxgY4k4PkVB7zfwzYbY3O9Lcqe3xufS5g==}
+
+  birpc@2.4.0:
+    resolution: {integrity: sha512-5IdNxTyhXHv2UlgnPHQ0h+5ypVmkrYHzL8QT+DwFZ//2N/oNV8Ch+BCRmTJ3x6/z9Axo/cXYBc9eprsUVK/Jsg==}
 
   blob-to-buffer@1.2.9:
     resolution: {integrity: sha512-BF033y5fN6OCofD3vgHmNtwZWRcq9NLyyxyILx9hfMy1sXYy4ojFl765hJ2lP0YaN2fuxPaLO2Vzzoxy0FLFFA==}
@@ -4020,11 +4023,11 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
-  dts-resolver@2.0.1:
-    resolution: {integrity: sha512-Pe2kqaQTNVxleYpt9Q9658fn6rEpoZbMbDpEBbcU6pnuGM3Q0IdM+Rv67kN6qcyp8Bv2Uv9NYy5Y1rG1LSgfoQ==}
+  dts-resolver@2.1.1:
+    resolution: {integrity: sha512-3BiGFhB6mj5Kv+W2vdJseQUYW+SKVzAFJL6YNP6ursbrwy1fXHRotfHi3xLNxe4wZl/K8qbAFeCDjZLjzqxxRw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      oxc-resolver: ^9.0.2
+      oxc-resolver: '>=11.0.0'
     peerDependenciesMeta:
       oxc-resolver:
         optional: true
@@ -4066,8 +4069,8 @@ packages:
   emojilib@2.4.0:
     resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
 
-  empathic@1.1.0:
-    resolution: {integrity: sha512-rsPft6CK3eHtrlp9Y5ALBb+hfK+DWnA4WFebbazxjWyx8vSm3rZeoM3z9irsjcqO3PYRzlfv27XIB4tz2DV7RA==}
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
 
   encoding@0.1.13:
@@ -6550,14 +6553,17 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rolldown-plugin-dts@0.13.4:
-    resolution: {integrity: sha512-2+3GnKj6A3wKfyomUKfONRHjgKE85X4PcgW1b84KkHvuN3mUuUiOMseLKafFLMF6NkqQPAJ3FErwtC4HuwIswg==}
+  rolldown-plugin-dts@0.13.13:
+    resolution: {integrity: sha512-Nchx9nQoa4IpfQ/BJzodKMvtJ3H3dT322siAJSp3uvQJ+Pi1qgEjOp7hSQwGSQRhaC5gC+9hparbWEH5oiAL9Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
+      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
       rolldown: ^1.0.0-beta.9
       typescript: ^5.0.0
       vue-tsc: ~2.2.0
     peerDependenciesMeta:
+      '@typescript/native-preview':
+        optional: true
       typescript:
         optional: true
       vue-tsc:
@@ -7080,6 +7086,10 @@ packages:
     resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.0.2:
     resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -7165,16 +7175,19 @@ packages:
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
-  tsdown@0.12.3:
-    resolution: {integrity: sha512-GFqQc6rP8EzsIDs4biOdh7sTveQpMVUv2GUgv7O0Z7yjnlGK050yw0PfUHBHi2xaSyN8K/ztU83DXyEl2upeGw==}
+  tsdown@0.12.9:
+    resolution: {integrity: sha512-MfrXm9PIlT3saovtWKf/gCJJ/NQCdE0SiREkdNC+9Qy6UHhdeDPxnkFaBD7xttVUmgp0yUHtGirpoLB+OVLuLA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
       publint: ^0.3.0
       typescript: ^5.0.0
       unplugin-lightningcss: ^0.4.0
       unplugin-unused: ^0.5.0
     peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
       publint:
         optional: true
       typescript:
@@ -10490,7 +10503,7 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
-  ansis@4.0.0: {}
+  ansis@4.1.0: {}
 
   any-promise@1.3.0: {}
 
@@ -10618,9 +10631,9 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-kit@2.0.0:
+  ast-kit@2.1.0:
     dependencies:
-      '@babel/parser': 7.27.2
+      '@babel/parser': 7.27.7
       pathe: 2.0.3
 
   ast-types-flow@0.0.8: {}
@@ -10776,6 +10789,8 @@ snapshots:
       is-windows: 1.0.2
 
   birpc@2.3.0: {}
+
+  birpc@2.4.0: {}
 
   blob-to-buffer@1.2.9: {}
 
@@ -11323,7 +11338,7 @@ snapshots:
 
   dset@3.1.4: {}
 
-  dts-resolver@2.0.1: {}
+  dts-resolver@2.1.1: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -11363,7 +11378,7 @@ snapshots:
 
   emojilib@2.4.0: {}
 
-  empathic@1.1.0: {}
+  empathic@2.0.0: {}
 
   encoding@0.1.13:
     dependencies:
@@ -14714,15 +14729,15 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rolldown-plugin-dts@0.13.4(rolldown@1.0.0-beta.9-commit.d91dfb5)(typescript@5.8.2):
+  rolldown-plugin-dts@0.13.13(rolldown@1.0.0-beta.9-commit.d91dfb5)(typescript@5.8.2):
     dependencies:
-      '@babel/generator': 7.27.1
-      '@babel/parser': 7.27.2
-      '@babel/types': 7.27.1
-      ast-kit: 2.0.0
-      birpc: 2.3.0
+      '@babel/generator': 7.27.5
+      '@babel/parser': 7.27.7
+      '@babel/types': 7.27.7
+      ast-kit: 2.1.0
+      birpc: 2.4.0
       debug: 4.4.1
-      dts-resolver: 2.0.1
+      dts-resolver: 2.1.1
       get-tsconfig: 4.10.1
       rolldown: 1.0.0-beta.9-commit.d91dfb5
     optionalDependencies:
@@ -14736,7 +14751,7 @@ snapshots:
       '@oxc-project/runtime': 0.71.0
       '@oxc-project/types': 0.71.0
       '@rolldown/pluginutils': 1.0.0-beta.9-commit.d91dfb5
-      ansis: 4.0.0
+      ansis: 4.1.0
     optionalDependencies:
       '@rolldown/binding-darwin-arm64': 1.0.0-beta.9-commit.d91dfb5
       '@rolldown/binding-darwin-x64': 1.0.0-beta.9-commit.d91dfb5
@@ -15424,6 +15439,11 @@ snapshots:
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tinyglobby@0.2.14:
+    dependencies:
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+
   tinypool@1.0.2: {}
 
   tinyrainbow@2.0.0: {}
@@ -15490,25 +15510,26 @@ snapshots:
       strip-bom: 3.0.0
     optional: true
 
-  tsdown@0.12.3(typescript@5.8.2)(unplugin-unused@0.5.0):
+  tsdown@0.12.9(typescript@5.8.2)(unplugin-unused@0.5.0):
     dependencies:
-      ansis: 4.0.0
+      ansis: 4.1.0
       cac: 6.7.14
       chokidar: 4.0.3
       debug: 4.4.1
       diff: 8.0.2
-      empathic: 1.1.0
+      empathic: 2.0.0
       hookable: 5.5.3
       rolldown: 1.0.0-beta.9-commit.d91dfb5
-      rolldown-plugin-dts: 0.13.4(rolldown@1.0.0-beta.9-commit.d91dfb5)(typescript@5.8.2)
+      rolldown-plugin-dts: 0.13.13(rolldown@1.0.0-beta.9-commit.d91dfb5)(typescript@5.8.2)
       semver: 7.7.2
       tinyexec: 1.0.1
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
       unconfig: 7.3.2
     optionalDependencies:
       typescript: 5.8.2
       unplugin-unused: 0.5.0
     transitivePeerDependencies:
+      - '@typescript/native-preview'
       - oxc-resolver
       - supports-color
       - vue-tsc

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,7 +25,7 @@ catalog:
   "react": ^19.1.0
   "satori": ^0.12.2
   "svelte": "^5.25.12"
-  "tsdown": ^0.12.3
+  "tsdown": ^0.12.9
   "typescript": ^5.8.2
   "vite": ^6.2.6
   "vitest": ^3.1.4

--- a/todo.txt
+++ b/todo.txt
@@ -1,3 +1,7 @@
+source maps:
+TODO: when https://github.com/rolldown/tsdown/issues/360 is fixed, remove `*.js.map` from all package.json files
+x 2025-07-06 TODO: whenever source maps are built, export them in package.json
+
 TODO: fix tests/e2e react ts errors, figure out why they aren't typechecking
 TODO: Look into npm Provenance w/ github actions
 


### PR DESCRIPTION
https://github.com/rolldown/tsdown/issues/360 makes it so that we are generating source maps. Consuming applications might (e.g. if they use Vite) see warnings about source maps referenced in the package js files that aren't in the package.

Temporarily fix by just publishing the .js.map files (even though they shouldn't be built).

Once ﻿https://github.com/rolldown/tsdown/issues/360 is fixed we can stop publishing these source maps.