### PR TITLE
astro-table-of-contents: fix typing

### DIFF
--- a/.changeset/open-parrots-warn.md
+++ b/.changeset/open-parrots-warn.md
@@ -1,0 +1,5 @@
+---
+"@altano/astro-table-of-contents": patch
+---
+
+fix re-exported types

--- a/packages/astro-table-of-contents/src/TableOfContentsWithScrollSpy.astro
+++ b/packages/astro-table-of-contents/src/TableOfContentsWithScrollSpy.astro
@@ -1,7 +1,8 @@
 ---
+import { ComponentProps } from "astro/types";
 import TableOfContents from "./TableOfContents.astro";
 
-export type { Props } from "./TableOfContents.astro";
+export type Props = ComponentProps<typeof TableOfContents>;
 ---
 
 <script>


### PR DESCRIPTION
type re-exports don't seem to work with .astro components, so re-export the type manually in two steps.