### PR TITLE
experiment: playwright 1.59.1 with newer nixpkgs (mesa 26.1.1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,8 +121,8 @@ jobs:
           '
       - name: Run tests
         run: nix develop .#test-e2e --command pnpm turbo run test:e2e --summarize
-        # env:
-        #   DEBUG: "pw:browser*"
+        env:
+          DEBUG: "pw:browser*"
       - name: Summarize Turbo
         uses: ./.github/actions/turbo-summarize
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/flake.lock
+++ b/flake.lock
@@ -18,17 +18,17 @@
     },
     "nixpkgs-playwright-1-59-1": {
       "locked": {
-        "lastModified": 1777918403,
-        "narHash": "sha256-7QiZv0LcW1yIOLo2LNuCQjWon1Z1r99FwK24hbtBOF4=",
+        "lastModified": 1780271817,
+        "narHash": "sha256-LSTTcdkGRXfAxoshh6ljRedRjBGWRg9/J54ZGW7BwF8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "afc5551119aae6eab73a95c1960891cfe63204f6",
+        "rev": "5f85796ab70f9a6ac935b366065d4565288947ac",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "afc5551119aae6eab73a95c1960891cfe63204f6",
+        "rev": "5f85796ab70f9a6ac935b366065d4565288947ac",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    # Pin playwright to 1.59.1. On 1.61.1, webkit e2e tests stop working in GitHub Actions.
-    nixpkgs-playwright-1-59-1.url = "github:NixOS/nixpkgs/afc5551119aae6eab73a95c1960891cfe63204f6";
+    # Bisection experiment: same playwright-driver version (1.59.1) as ryp, but
+    # from a newer nixpkgs revision (mesa 26.1.1 instead of 26.0.6) to test
+    # whether mesa itself, not playwright, causes webkit e2e to fail in CI.
+    nixpkgs-playwright-1-59-1.url = "github:NixOS/nixpkgs/5f85796ab70f9a6ac935b366065d4565288947ac";
   };
 
   outputs =


### PR DESCRIPTION
Bisection step isolating mesa from playwright version: same playwright-driver 1.59.1 as #318, but sourced from a newer nixpkgs rev (mesa 26.1.1 instead of 26.0.6). If webkit e2e still fails here, mesa (not playwright/webkit build) is the regression trigger. Throwaway.