### PR TITLE
experiment: playwright 1.61.1 with old mesa 26.0.6 via LD_LIBRARY_PATH

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,11 +118,15 @@ jobs:
             ls -la "$PLAYWRIGHT_BROWSERS_PATH"/webkit-*/
             echo "--- testing webkit binary ---"
             ldd "$PLAYWRIGHT_BROWSERS_PATH"/webkit-*/minibrowser-wpe/MiniBrowser 2>&1 | grep "not found" || echo "all libs found"
+            echo "--- LD_LIBRARY_PATH ---"
+            echo "$LD_LIBRARY_PATH"
+            echo "--- resolved libEGL ---"
+            ldd "$PLAYWRIGHT_BROWSERS_PATH"/webkit-*/minibrowser-wpe/MiniBrowser 2>&1 | grep -i egl || echo "no egl entry in ldd output"
           '
       - name: Run tests
         run: nix develop .#test-e2e --command pnpm turbo run test:e2e --summarize
-        # env:
-        #   DEBUG: "pw:browser*"
+        env:
+          DEBUG: "pw:browser*"
       - name: Summarize Turbo
         uses: ./.github/actions/turbo-summarize
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/flake.lock
+++ b/flake.lock
@@ -16,7 +16,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-playwright-1-59-1": {
+    "nixpkgs-mesa-26-0-6": {
       "locked": {
         "lastModified": 1777918403,
         "narHash": "sha256-7QiZv0LcW1yIOLo2LNuCQjWon1Z1r99FwK24hbtBOF4=",
@@ -35,7 +35,7 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "nixpkgs-playwright-1-59-1": "nixpkgs-playwright-1-59-1"
+        "nixpkgs-mesa-26-0-6": "nixpkgs-mesa-26-0-6"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,15 +3,17 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    # Pin playwright to 1.59.1. On 1.61.1, webkit e2e tests stop working in GitHub Actions.
-    nixpkgs-playwright-1-59-1.url = "github:NixOS/nixpkgs/afc5551119aae6eab73a95c1960891cfe63204f6";
+    # Bisection experiment: playwright 1.61.1 (current/latest) unmodified, but
+    # force the old (known-working) mesa 26.0.6 onto LD_LIBRARY_PATH ahead of
+    # whatever mesa 1.61.1's own nixpkgs revision would otherwise provide.
+    nixpkgs-mesa-26-0-6.url = "github:NixOS/nixpkgs/afc5551119aae6eab73a95c1960891cfe63204f6";
   };
 
   outputs =
     {
       self,
       nixpkgs,
-      nixpkgs-playwright-1-59-1,
+      nixpkgs-mesa-26-0-6,
     }:
     let
       supportedSystems = [
@@ -35,17 +37,17 @@
         system:
         let
           pkgs = import nixpkgs { inherit system; };
-          pkgsPlaywright159 = import nixpkgs-playwright-1-59-1 { inherit system; };
+          pkgsOldMesa = import nixpkgs-mesa-26-0-6 { inherit system; };
           # Assert playwright-driver version matches @playwright/test from pnpm-lock.yaml
           playwrightVersionCheck =
             assert
-              pkgsPlaywright159.playwright-driver.version == expectedPlaywrightVersion
+              pkgs.playwright-driver.version == expectedPlaywrightVersion
               || builtins.throw ''
                 Playwright version mismatch!
-                  nixpkgs-playwright-1-59-1 has: ${pkgsPlaywright159.playwright-driver.version}
+                  nixpkgs has: ${pkgs.playwright-driver.version}
                   pnpm-lock.yaml expects: ${expectedPlaywrightVersion}
 
-                Fix: update the nixpkgs-playwright-1-59-1 input or the Playwright npm dependency so both resolve to the same version.
+                Fix: update the nixpkgs input or the Playwright npm dependency so both resolve to the same version.
               '';
             true;
 
@@ -70,7 +72,7 @@
 
           playwrightBrowsers =
             assert playwrightVersionCheck;
-            pkgsPlaywright159.playwright-driver.browsers;
+            pkgs.playwright-driver.browsers;
 
           localExtras = [
             pkgs.difftastic
@@ -102,6 +104,7 @@
             PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsers}";
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = 1;
             PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = 1;
+            LD_LIBRARY_PATH = "${pkgsOldMesa.mesa}/lib";
           };
         }
       );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: 5.2.6
       version: 5.2.6
     '@playwright/test':
-      specifier: 1.59.1
-      version: 1.59.1
+      specifier: 1.61.1
+      version: 1.61.1
     '@types/mdast':
       specifier: ^4.0.4
       version: 4.0.4
@@ -121,7 +121,7 @@ importers:
         version: 2.30.0(@types/node@26.1.1)
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.61.1
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.4.2)
@@ -277,7 +277,7 @@ importers:
         version: 2.0.0(astro@7.1.1(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.1)(jiti@2.4.2)(rollup@4.60.0)(yaml@2.8.3))
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.61.1
       '@types/he':
         specifier: ^1.2.3
         version: 1.2.3
@@ -415,7 +415,7 @@ importers:
         version: 0.9.9(prettier@3.8.1)(typescript@5.9.3)
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.61.1
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.1
@@ -965,7 +965,7 @@ importers:
         version: 5.2.6
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.61.1
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
@@ -1044,7 +1044,7 @@ importers:
         version: 0.18.2
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.61.1
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.1
@@ -1086,7 +1086,7 @@ importers:
         version: 0.18.2
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.61.1
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.1
@@ -1235,7 +1235,7 @@ importers:
         version: 0.18.2
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.61.1
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.1
@@ -1296,7 +1296,7 @@ importers:
         version: 0.18.2
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.61.1
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.1
@@ -2583,8 +2583,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6214,13 +6214,13 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9120,9 +9120,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.61.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -13401,11 +13401,11 @@ snapshots:
       pathe: 2.0.3
     optional: true
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.59.1:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   "@astrojs/vue": ^7.0.1
   "@fontsource-variable/inter": 5.2.6
   "@fontsource/inter": 5.2.6
-  "@playwright/test": 1.59.1
+  "@playwright/test": 1.61.1
   "@types/mdast": ^4.0.4
   "@types/node": ^26.1.1
   "@types/react": ^19.2.10


### PR DESCRIPTION
Bisection control: playwright 1.61.1's own webkit-2311 build, unmodified, but with mesa 26.0.6 (known-good) forced onto LD_LIBRARY_PATH ahead of whatever mesa 1.61.1's nixpkgs rev would otherwise provide. If this passes, confirms mesa is the sole cause and we can safely upgrade playwright as long as mesa stays pinned. Throwaway.