### PR TITLE
experiment: validate LD_LIBRARY_PATH mesa override (negative control)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,11 +118,15 @@ jobs:
             ls -la "$PLAYWRIGHT_BROWSERS_PATH"/webkit-*/
             echo "--- testing webkit binary ---"
             ldd "$PLAYWRIGHT_BROWSERS_PATH"/webkit-*/minibrowser-wpe/MiniBrowser 2>&1 | grep "not found" || echo "all libs found"
+            echo "--- LD_LIBRARY_PATH ---"
+            echo "$LD_LIBRARY_PATH"
+            echo "--- resolved libEGL ---"
+            ldd "$PLAYWRIGHT_BROWSERS_PATH"/webkit-*/minibrowser-wpe/MiniBrowser 2>&1 | grep -i egl || echo "no egl entry in ldd output"
           '
       - name: Run tests
         run: nix develop .#test-e2e --command pnpm turbo run test:e2e --summarize
-        # env:
-        #   DEBUG: "pw:browser*"
+        env:
+          DEBUG: "pw:browser*"
       - name: Summarize Turbo
         uses: ./.github/actions/turbo-summarize
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-mesa-26-1-1": {
+      "locked": {
+        "lastModified": 1780271817,
+        "narHash": "sha256-LSTTcdkGRXfAxoshh6ljRedRjBGWRg9/J54ZGW7BwF8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5f85796ab70f9a6ac935b366065d4565288947ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5f85796ab70f9a6ac935b366065d4565288947ac",
+        "type": "github"
+      }
+    },
     "nixpkgs-playwright-1-59-1": {
       "locked": {
         "lastModified": 1777918403,
@@ -35,6 +51,7 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
+        "nixpkgs-mesa-26-1-1": "nixpkgs-mesa-26-1-1",
         "nixpkgs-playwright-1-59-1": "nixpkgs-playwright-1-59-1"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,10 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     # Pin playwright to 1.59.1. On 1.61.1, webkit e2e tests stop working in GitHub Actions.
     nixpkgs-playwright-1-59-1.url = "github:NixOS/nixpkgs/afc5551119aae6eab73a95c1960891cfe63204f6";
+    # Negative control: known-bad mesa 26.1.1, forced onto LD_LIBRARY_PATH over
+    # the otherwise-good 1.59.1/26.0.6 combo above, to check that the
+    # LD_LIBRARY_PATH override mechanism actually takes effect at runtime.
+    nixpkgs-mesa-26-1-1.url = "github:NixOS/nixpkgs/5f85796ab70f9a6ac935b366065d4565288947ac";
   };
 
   outputs =
@@ -12,6 +16,7 @@
       self,
       nixpkgs,
       nixpkgs-playwright-1-59-1,
+      nixpkgs-mesa-26-1-1,
     }:
     let
       supportedSystems = [
@@ -36,6 +41,7 @@
         let
           pkgs = import nixpkgs { inherit system; };
           pkgsPlaywright159 = import nixpkgs-playwright-1-59-1 { inherit system; };
+          pkgsBadMesa = import nixpkgs-mesa-26-1-1 { inherit system; };
           # Assert playwright-driver version matches @playwright/test from pnpm-lock.yaml
           playwrightVersionCheck =
             assert
@@ -102,6 +108,7 @@
             PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsers}";
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = 1;
             PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = 1;
+            LD_LIBRARY_PATH = "${pkgsBadMesa.mesa}/lib";
           };
         }
       );


### PR DESCRIPTION
Sanity check for the LD_LIBRARY_PATH override mechanism used in #342: known-good playwright 1.59.1 + mesa 26.0.6, but with known-bad mesa 26.1.1 forced onto LD_LIBRARY_PATH. If this fails the same way, the override mechanism is confirmed to work at runtime and #342's result is trustworthy. Throwaway.